### PR TITLE
Showed how you should add django_socketio.urls to your urlconf.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,9 +82,14 @@ from source::
     $ python setup.py install
 
 Once installed you can then add ``django_socketio`` to your
-``INSTALLED_APPS`` and ``django_socketio.urls`` to your url conf. The
-client-side JavaScripts for Socket.IO and its extensions can then be
-added to any page with the ``socketio`` templatetag::
+``INSTALLED_APPS`` and ``django_socketio.urls`` to your url conf::
+
+    urlpatterns = patterns('',
+        url("", include('django_socketio.urls')),
+    )
+
+The client-side JavaScripts for Socket.IO and its extensions can then 
+be added to any page with the ``socketio`` templatetag::
 
     <head>
         {% load socketio_tags %}


### PR DESCRIPTION
When I installed django-socketio, I wasn't sure how to add the socketio.urls, so I just did what I always did: gave it a path that made sense to me.
    url(r'^io/', include('django_socketio.urls')),
I then spent the next 5 hours trying to figure out why my javascript said it was connecting, but runserver-socketio acknowledged nothing.

TLDR:
I added an example of what you're supposed to do to the documentation.
