### PR TITLE
Fix .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python:
   - "2.5"
   - "2.6"
   - "2.7"
-before_script: "sudo apt-get install python-dev libevent-dev"
+before_install: "sudo apt-get install python-dev libevent-dev"
 install: pip install . --use-mirrors
 script: ./django_socketio/example_project/manage.py test


### PR DESCRIPTION
The apt-get command is mistakenly as before_script when it should be before_install. This causes the headers not to be available when pip is run which causes pip to fail.
