### PR TITLE
Handle the jQuery.io = this.io when jQuery exists but is undefined

### DIFF
--- a/django_socketio/static/js/socket.io.js
+++ b/django_socketio/static/js/socket.io.js
@@ -17,7 +17,16 @@ this.io = {
 	}
 };
 
-if ('jQuery' in this) jQuery.io = this.io;
+try {
+  if ('jQuery' in this)
+    jQuery.io = this.io;
+} catch (e) {
+  try {
+    if ('django' in this && 'jQuery' in django)
+      django.jQuery.io = this.io;
+  } catch (e) {
+  }
+}
 
 if (typeof window != 'undefined'){
   // WEB_SOCKET_SWF_LOCATION = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '//cdn.socket.io/' + this.io.version + '/WebSocketMain.swf';


### PR DESCRIPTION
I'm using `django-grappelli`, and it moves jQuery from `this.jQuery` to `this.django.jQuery`.  The `this.jQuery` variable still seems to be around, but it's `undefined`.  There was an error with `jQuery.io = this.io`, because you can't set attributes on undefined objects.  Because of this error, the rest of the script was not processed, causing the sockets to not work at all.

This is a little workaround for my particular scenario, but it also handles the error gracefully.
