### PR TITLE
drop support for django 1.3 as last supported django is 1.4

### DIFF
--- a/django_socketio/example_project/chat/urls.py
+++ b/django_socketio/example_project/chat/urls.py
@@ -1,5 +1,5 @@
 
-from django.conf.urls.defaults import patterns, include, url
+from django.conf.urls import patterns, url
 
 
 urlpatterns = patterns("chat.views",

--- a/django_socketio/urls.py
+++ b/django_socketio/urls.py
@@ -1,8 +1,4 @@
-# Patch for django 1.3 compatibility
-try:
-    from django.conf.urls import patterns, url
-except ImportError:
-    from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 from django.conf import settings
 from django.utils.importlib import import_module


### PR DESCRIPTION
Removed deprecated urls from django 1.3
