### PR TITLE
fixed example_project 1.7 compatibility

### DIFF
--- a/django_socketio/example_project/settings.py
+++ b/django_socketio/example_project/settings.py
@@ -40,7 +40,7 @@ MIDDLEWARE_CLASSES = (
 
 STATIC_URL = "/static/"
 ROOT_URLCONF = "%s.urls" % PROJECT_DIR
-TEMPLATE_DIRS = full_path("templates")
+TEMPLATE_DIRS = list(full_path("templates"))
 #LOGIN_URL = "/admin/"
 
 INSTALLED_APPS = (


### PR DESCRIPTION
Fixes this error on 1.7:
django.core.exceptions.ImproperlyConfigured: The TEMPLATE_DIRS setting must be a tuple. Please fix your settings.