### PR TITLE
use static template tag instead of STATIC_URL

### DIFF
--- a/django_socketio/example_project/chat/templates/base.html
+++ b/django_socketio/example_project/chat/templates/base.html
@@ -1,10 +1,12 @@
+{% load static %}
+
 <!doctype html>
 <html lang="en">
 <head>
 
     <meta charset="utf-8">
     <title>{% block title %}Chat{% endblock %}</title>
-    <link rel="stylesheet" href="{{ STATIC_URL }}css/chat.css">
+    <link rel="stylesheet" href="{% static 'css/chat.css' %}">
     {% block extra_css %}{% endblock %}
     <script src="http://code.jquery.com/jquery-latest.min.js"></script>
     <script>

--- a/django_socketio/templates/socketio_scripts.html
+++ b/django_socketio/templates/socketio_scripts.html
@@ -1,4 +1,6 @@
-<script src="{{ STATIC_URL|default:MEDIA_URL }}js/socket.io.js"></script>
+{% load static %}
+
+<script src="{% static 'js/socket.io.js' %}"></script>
 <script>
 
 (function() {


### PR DESCRIPTION
My project totaly refuse to render STATIC_URL in template despite of
```python
  STATIC_URL = '/static/'
```
set in my settings.py

also use STATIC_URL in templates is ugly