### PR TITLE
pattern no longer supported

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,9 +88,9 @@ from source::
 Once installed you can then add ``django_socketio`` to your
 ``INSTALLED_APPS`` and ``django_socketio.urls`` to your url conf::
 
-    urlpatterns = patterns('',
+    urlpatterns += [
         url("", include('django_socketio.urls')),
-    )
+    ]
 
 The client-side JavaScripts for Socket.IO and its extensions can then
 be added to any page with the ``socketio`` templatetag::


### PR DESCRIPTION
The old syntax using urlpattern = pattern('', url(...)) is deprecated :

https://docs.djangoproject.com/en/1.8/internals/deprecation/#deprecation-removed-in-1-10

It might cause problems for users trying to make it work on newer versions of Django