### PR TITLE
django.utils.importlib deprecated since 1.9

### DIFF
--- a/django_socketio/urls.py
+++ b/django_socketio/urls.py
@@ -1,7 +1,12 @@
 from django.conf.urls import patterns, url
 
 from django.conf import settings
-from django.utils.importlib import import_module
+try:
+    # Django < 1.9
+    from django.utils.importlib import import_module
+except:
+    # Django >= 1.9
+    from importlib import import_module
 
 
 # Try and import an ``events`` module in each installed app,


### PR DESCRIPTION
added exception for newer versions of Django